### PR TITLE
bgfx::File constructor doesn't take any parameters

### DIFF
--- a/tools/brtshaderc/brtshaderc.cpp
+++ b/tools/brtshaderc/brtshaderc.cpp
@@ -238,7 +238,8 @@ namespace shaderc
         // set varyingdef
         std::string defaultVarying = dir + "varying.def.sc";
         const char* varyingdef = varyingPath ? varyingPath : defaultVarying.c_str();
-        bgfx::File attribdef(varyingdef);
+        bgfx::File attribdef;
+        attribdef.load(varyingdef);
         const char* parse = attribdef.getData();
         if (NULL != parse
         &&  *parse != '\0')
@@ -480,7 +481,8 @@ namespace shaderc
         {
             std::string defaultVarying = dir + "varying.def.sc";
             const char* varyingdef = cmdLine.findOption("varyingdef", defaultVarying.c_str() );
-            File attribdef(varyingdef);
+            File attribdef;
+            attribdef.load(varyingdef);
             const char* parse = attribdef.getData();
             if (NULL != parse
             &&  *parse != '\0')


### PR DESCRIPTION
Not sure how recently the API changed, but based on latest bgfx you have to call `load` explicitly